### PR TITLE
In netlify wrong number of args for abs url

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -2,6 +2,6 @@ baseURL = "http://example.org/"
 languageCode = "en-us"
 title = "Awesome Lighting Inc."
 theme = "hugo-shopping-product-catalogue-simple"
-themesDir = "themes"
+
 [Params]
 description = ""

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -2,6 +2,6 @@ baseURL = "http://example.org/"
 languageCode = "en-us"
 title = "Awesome Lighting Inc."
 theme = "hugo-shopping-product-catalogue-simple"
-themesDir = "../.."
+themesDir = "themes"
 [Params]
 description = ""

--- a/exampleSite/content/products/alessa.md
+++ b/exampleSite/content/products/alessa.md
@@ -4,7 +4,7 @@
     "tags": ["Wall Light", "ambience", "black", "black metal", "contemporary", "cool", "cozy", "edison bulb", "filament bulb", "glass", "green", "indoor", "light", "metal", "MODERN", "round", "rustic", "vintage", "white"],
     "categories": ["Wall Light"],
     "images": ["img/alessa/1.png", "img/alessa/2.jpg", "img/alessa/3.jpg", "img/alessa/4.jpg", "img/alessa/5.jpg", "img/alessa/6.jpg"],
-    "thumbnailImage": "img/alessa/thumnail.png",
+    "thumbnailImage": "/img/alessa/thumnail.png",
     "actualPrice": null,
     "comparePrice": null,
     "inStock": null,

--- a/exampleSite/content/products/azure-blue-de-stijl-bedside-retro-light-with-black-ring.md
+++ b/exampleSite/content/products/azure-blue-de-stijl-bedside-retro-light-with-black-ring.md
@@ -4,7 +4,7 @@
     "tags": ["Wall Light"],
     "categories": ["Wall Light"],
     "images" : ["img/azure-blue-de-stijl-bedside-retro-light-with-black-ring/1.jpg"],
-    "thumbnailImage": "img/azure-blue-de-stijl-bedside-retro-light-with-black-ring/thumbnail.jpg",
+    "thumbnailImage": "/img/azure-blue-de-stijl-bedside-retro-light-with-black-ring/thumbnail.jpg",
     "actualPrice": null,
     "comparePrice": null,
     "inStock": null,

--- a/exampleSite/content/products/duke.md
+++ b/exampleSite/content/products/duke.md
@@ -4,7 +4,7 @@
     "tags": ["Floor Light"],
     "categories": ["Floor Light"],
     "images": ["img/duke/1.jpg", "img/duke/2.jpg", "img/duke/3.jpg"],
-    "thumbnailImage": "img/duke/thumbnail.jpg",
+    "thumbnailImage": "/img/duke/thumbnail.jpg",
     "actualPrice": "₹ 87,341.00",
     "comparePrice": null,
     "inStock": true,

--- a/exampleSite/content/products/industrial-mesh-cage-wall-light-metal-mesh-up.md
+++ b/exampleSite/content/products/industrial-mesh-cage-wall-light-metal-mesh-up.md
@@ -4,7 +4,7 @@
     "tags": ["Wall Light"],
     "categories": ["Wall Light"],
     "images": ["img/industrial-mesh-cage-wall-light-metal-mesh-up/1.png", "img/industrial-mesh-cage-wall-light-metal-mesh-up/2.jpg", "img/industrial-mesh-cage-wall-light-metal-mesh-up/3.jpg"],
-    "thumbnailImage": "img/industrial-mesh-cage-wall-light-metal-mesh-up/thumbnail.png",
+    "thumbnailImage": "/img/industrial-mesh-cage-wall-light-metal-mesh-up/thumbnail.png",
     "actualPrice": "₹ 4608.00",
     "comparePrice": "₹ 5000.00",
     "inStock": false,

--- a/exampleSite/content/products/modo-21-lamp.md
+++ b/exampleSite/content/products/modo-21-lamp.md
@@ -4,7 +4,7 @@
     "tags": ["chandeliers"],
     "categories": ["chandeliers"],
     "images": ["img/modo-21-lamp/1.jpg", "img/modo-21-lamp/2.jpg", "img/modo-21-lamp/2.jpg"],
-    "thumbnailImage": "img/modo-21-lamp/thumbnail.jpg",
+    "thumbnailImage": "/img/modo-21-lamp/thumbnail.jpg",
     "actualPrice": "₹ 85,000.00",
     "comparePrice": null,
     "inStock": true,

--- a/exampleSite/content/products/oda-lamp.md
+++ b/exampleSite/content/products/oda-lamp.md
@@ -4,7 +4,7 @@
     "tags": ["Floor Light"],
     "categories": ["Floor Light"],
     "images": ["img/oda-lamp/1.jpg", "img/oda-lamp/2.jpg"],
-    "thumbnailImage": "img/oda-lamp/thumbnail.jpg",
+    "thumbnailImage": "/img/oda-lamp/thumbnail.jpg",
     "actualPrice": "₹ 12,960.00",
     "comparePrice": "₹ 25,920.00",
     "inStock": false,

--- a/exampleSite/content/products/retro-vintage-industrial-cage-pendant-system.md
+++ b/exampleSite/content/products/retro-vintage-industrial-cage-pendant-system.md
@@ -4,7 +4,7 @@
     "tags": ["Pendant Light"],
     "categories": ["Pendant Light"],
     "images": ["img/retro-vintage-industrial-cage-pendant-system/1.png", "img/retro-vintage-industrial-cage-pendant-system/2.png"],
-    "thumbnailImage": "img/retro-vintage-industrial-cage-pendant-system/thumbnail.png",
+    "thumbnailImage": "/img/retro-vintage-industrial-cage-pendant-system/thumbnail.png",
     "actualPrice": "₹ 3,744.00",
     "comparePrice": null,
     "inStock": true,

--- a/exampleSite/content/products/void-pendant.md
+++ b/exampleSite/content/products/void-pendant.md
@@ -4,7 +4,7 @@
     "tags": ["Pendant Light"],
     "categories": ["Pendant Light"],
     "images": ["img/void-pendant/1.jpg", "img/void-pendant/2.jpg", "img/void-pendant/3.jpg", "img/void-pendant/4.jpg"],
-    "thumbnailImage": "img/void-pendant/thumbnail.jpg",
+    "thumbnailImage": "/img/void-pendant/thumbnail.jpg",
     "comparePrice": null,
     "actualPrice": "₹ 18,500.00",
     "inStock": true,

--- a/layouts/partials/products/list/product-list-item.html
+++ b/layouts/partials/products/list/product-list-item.html
@@ -1,5 +1,5 @@
 <a class="col-6 col-lg-3" href="{{ .RelPermalink }}" style="color: inherit;">
-    <img class="b-lazy img-fluid text-center" data-src="{{ .Params.thumbnailImage | absURL }}" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" />
+    <img class="b-lazy img-fluid text-center" data-src="{{ .Params.thumbnailImage }}" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" />
     <p class="text-left">
         <span style="font-size: 13px">{{ .Params.title }}</span>
         <br/>


### PR DESCRIPTION
Hello,

Thanks for cool hugo theme! 
Big thumps up :)

I had small an issue to apply theme to netlify cms, [here](https://github.com/netlify-templates/one-click-hugo-cms). Changes added for netlify cms. Sorry in advance if pull request missing prerequisites, please let me know if it is necessary to update.

Issue appeared with:
Hugo Static Site Generator: v0.51/extended darwin/amd64
Go: go version go1.11.2 darwin/amd64

Apply theme and during site generation, received stack trace below using layout:
Error while rendering "taxonomyTerm" in "": template: categories/list.html:2:5: executing "main" at <partial "products/li...>: error calling partial: template: partials/products/list/product-list.html:13:15: executing "partials/products/list/product-list.html" at <partial "products/li...>: error calling partial: template: partials/products/list/product-list-item.html:2:84: executing "partials/products/list/product-list-item.html" at <absURL>: wrong number of args for absURL: want 1 got 0